### PR TITLE
Implement API-based login flow

### DIFF
--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,33 +1,136 @@
-import { useEffect, useState } from "react";
+import { useSyncExternalStore } from "react";
 
-type Role = "client" | "photographer" | "admin";
+export type Role = "client" | "photographer" | "admin";
 export type User = { id: string; email: string; role: Role };
 
-const KEY = "pm_auth_user";
+const API = import.meta.env.VITE_API_URL || "http://localhost:5174";
 
-function read(): User | null {
+const USER_KEY = "pm_auth_user";
+const TOKEN_KEY = "pm_auth_token";
+
+type AuthState = { user: User | null; token: string | null };
+
+const subscribers = new Set<() => void>();
+
+function readUser(): User | null {
+  if (typeof window === "undefined") return null;
   try {
-    const raw = localStorage.getItem(KEY);
+    const raw = window.localStorage.getItem(USER_KEY);
     return raw ? (JSON.parse(raw) as User) : null;
   } catch {
     return null;
   }
 }
-function write(u: User | null) {
-  if (u) localStorage.setItem(KEY, JSON.stringify(u));
-  else localStorage.removeItem(KEY);
+
+function writeUser(u: User | null) {
+  if (typeof window === "undefined") return;
+  try {
+    if (u) window.localStorage.setItem(USER_KEY, JSON.stringify(u));
+    else window.localStorage.removeItem(USER_KEY);
+  } catch {
+    // ignore storage errors (private mode, etc.)
+  }
+}
+
+function readToken(): string | null {
+  if (typeof window === "undefined") return null;
+  try {
+    return window.localStorage.getItem(TOKEN_KEY);
+  } catch {
+    return null;
+  }
+}
+
+function writeToken(token: string | null) {
+  if (typeof window === "undefined") return;
+  try {
+    if (token) window.localStorage.setItem(TOKEN_KEY, token);
+    else window.localStorage.removeItem(TOKEN_KEY);
+  } catch {
+    // ignore storage errors
+  }
+}
+
+let state: AuthState = { user: readUser(), token: readToken() };
+
+const getSnapshot = () => state;
+const getServerSnapshot = () => state;
+
+function subscribe(listener: () => void) {
+  subscribers.add(listener);
+  return () => subscribers.delete(listener);
+}
+
+function emit() {
+  subscribers.forEach((listener) => listener());
+}
+
+function setState(next: AuthState) {
+  state = { ...next };
+  writeUser(state.user);
+  writeToken(state.token);
+  emit();
+}
+
+async function login(email: string, password: string) {
+  const response = await fetch(`${API}/auth/login`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ email, password }),
+  });
+
+  let payload: unknown;
+  try {
+    payload = await response.json();
+  } catch {
+    payload = null;
+  }
+
+  if (!response.ok) {
+    const errorMessage =
+      payload && typeof (payload as any).error === "string"
+        ? (payload as any).error
+        : "Nie udało się zalogować. Sprawdź dane i spróbuj ponownie.";
+    throw new Error(errorMessage);
+  }
+
+  const data = payload as { token?: string; user?: User } | null;
+  if (!data?.token || !data.user) {
+    throw new Error("Błędna odpowiedź serwera podczas logowania.");
+  }
+
+  setState({ user: data.user, token: data.token });
+  return data.user;
+}
+
+function loginDemo(email: string, role: Role) {
+  const user: User = {
+    id: globalThis.crypto?.randomUUID?.() ?? `${Date.now()}`,
+    email,
+    role,
+  };
+  const token = `demo-${globalThis.crypto?.randomUUID?.() ?? Math.random().toString(36).slice(2)}`;
+  setState({ user, token });
+  return user;
+}
+
+function logout() {
+  setState({ user: null, token: null });
+}
+
+export function getAuthToken() {
+  return state.token;
 }
 
 export function useAuth() {
-  const [user, setUser] = useState<User | null>(() => read());
-  useEffect(() => setUser(read()), []);
-
-  const login = (email: string, role: Role) => {
-    const u: User = { id: crypto.randomUUID?.() || String(Date.now()), email, role };
-    write(u); setUser(u);
-    return u;
+  const snapshot = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+  return {
+    user: snapshot.user,
+    token: snapshot.token,
+    isLoggedIn: !!snapshot.user,
+    login,
+    loginDemo,
+    logout,
   };
-  const logout = () => { write(null); setUser(null); };
-
-  return { user, login, logout, isLoggedIn: !!user };
 }
+

--- a/src/pages/auth/login.tsx
+++ b/src/pages/auth/login.tsx
@@ -6,14 +6,34 @@ export default function LoginPage() {
   const { login } = useAuth();
   const nav = useNavigate();
   const [email, setEmail] = useState("");
-  const [role, setRole] = useState<"photographer" | "admin" | "client">("photographer");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
 
-  const submit = (e: React.FormEvent) => {
+  const submit = async (e: React.FormEvent) => {
     e.preventDefault();
-    login(email || "demo@example.com", role);
-    if (role === "photographer") nav("/dashboard/photographer");
-    else if (role === "admin") nav("/dashboard/admin");
-    else nav("/");
+    if (!email.trim() || !password.trim()) {
+      setError("Podaj e-mail oraz hasło.");
+      return;
+    }
+
+    setError(null);
+    setLoading(true);
+    try {
+      const user = await login(email.trim(), password);
+      if (user.role === "photographer") {
+        nav("/dashboard/photographer", { replace: true });
+      } else if (user.role === "admin") {
+        nav("/dashboard/admin", { replace: true });
+      } else {
+        nav("/", { replace: true });
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Nie udało się zalogować.";
+      setError(message);
+    } finally {
+      setLoading(false);
+    }
   };
 
   return (
@@ -25,21 +45,23 @@ export default function LoginPage() {
           placeholder="E-mail"
           value={email}
           onChange={(e) => setEmail(e.target.value)}
+          autoComplete="email"
           autoFocus
         />
-        <select
+        <input
           className="w-full px-3 py-2 rounded-lg border"
-          value={role}
-          onChange={(e) => setRole(e.target.value as any)}
-        >
-          <option value="photographer">Fotograf</option>
-          <option value="admin">Admin</option>
-          <option value="client">Klient (podgląd)</option>
-        </select>
+          placeholder="Hasło"
+          type="password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          autoComplete="current-password"
+        />
+        {error && <p className="text-sm text-red-600">{error}</p>}
         <button
-          className="w-full px-4 py-2 rounded-lg bg-blue-600 text-white font-semibold hover:bg-blue-700"
+          className="w-full px-4 py-2 rounded-lg bg-blue-600 text-white font-semibold hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed"
+          disabled={loading}
         >
-          Zaloguj
+          {loading ? "Logowanie…" : "Zaloguj"}
         </button>
       </form>
       <p className="text-sm text-zinc-600">
@@ -51,3 +73,4 @@ export default function LoginPage() {
     </section>
   );
 }
+

--- a/src/pages/auth/register_photographer.tsx
+++ b/src/pages/auth/register_photographer.tsx
@@ -5,7 +5,7 @@ import { useAuth } from "@/hooks/useAuth";
 
 export default function RegisterPhotographerPage() {
   const nav = useNavigate();
-  const { login } = useAuth();
+  const { loginDemo } = useAuth();
 
   const [fullName, setFullName] = useState("");
   const [city, setCity] = useState("");
@@ -22,7 +22,7 @@ export default function RegisterPhotographerPage() {
       status: "submitted",
     });
     // Automatycznie logujemy jako fotograf (demo)
-    login(email || "nowy@fotograf.pl", "photographer");
+    loginDemo(email || "nowy@fotograf.pl", "photographer");
     nav("/dashboard/photographer");
   };
 


### PR DESCRIPTION
## Summary
- replace the auth hook with a shared store that calls `/auth/login`, keeps the JWT in memory/localStorage, and clears both on logout
- update the login page to collect credentials, surface API errors, and redirect according to the returned user role
- adapt the photographer registration flow to reuse the demo login helper

## Testing
- npm install *(fails: command hung in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c9019ddde083249935570bace53f19