### PR TITLE
Create minimal PixMemo MVP implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
-# pixmemo
+# PixMemo MVP
+
+Repozytorium zawiera uproszczoną implementację MVP aplikacji PixMemo opisaną w dokumentacji produktowej.
+
+## Struktura
+- `backend/` — serwer HTTP w czystym Node.js udostępniający mockowe API.
+- `frontend/` — statyczny interfejs PWA komunikujący się z API.
+- `docs/` — materiały analityczne dostarczone wcześniej.
+
+## Szybki start
+1. **API**
+   ```bash
+   cd backend
+   npm start
+   ```
+   Serwer uruchomi się na porcie `4000` i będzie obsługiwał endpointy `/api`.
+
+2. **Frontend**
+   Serwuj katalog `frontend/` jako statyczne pliki (np. `npx http-server frontend -p 5173`).
+   Następnie odwiedź `http://localhost:5173/index.html`.
+   Aplikacja automatycznie wykryje swój katalog (`/` lub `/pixmemo/`) i
+   oczekuje, że API będzie działać pod `http://localhost:4000/api`.
+
+## Ograniczenia
+- Implementacja korzysta z danych mockowych (brak bazy danych i płatności).
+- Walidacje i logika płatności są uproszczone do potrzeb dema.
+- Ze względu na brak dostępu do menedżera pakietów w środowisku zadania użyto rozwiązań bez zależności zewnętrznych.

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,22 @@
+# PixMemo API (Node.js bez zależności zewnętrznych)
+
+Prosty serwer HTTP w czystym Node.js udostępniający minimalny zestaw endpointów opisanych w dokumentacji PixMemo. Implementacja korzysta z danych mockowych i zapisuje rezerwacje w pliku `src/storage/bookings.json`.
+
+## Endpointy
+- `GET /api/healthz` — status API.
+- `GET /api/photographers` — lista fotografów (opcjonalny parametr `city`).
+- `GET /api/photographers/:id` — szczegóły fotografa.
+- `GET /api/photographers/:id/availability` — dostępne terminy.
+- `POST /api/bookings` — utworzenie rezerwacji (walidacja terminu i wymaganych pól).
+- `GET /api/bookings/:id` — podgląd utworzonej rezerwacji.
+
+## Uruchomienie
+```bash
+npm start
+```
+Serwer nasłuchuje na porcie `4000` (konfigurowalny przez zmienną `PORT`).
+
+## Dane i walidacja
+- Fotografowie są wczytywani z `src/data.js`.
+- Rezerwacje zapisywane są w pliku JSON (persistencja między restartami).
+- Walidacja sprawdza wymagane pola oraz dostępność slotu czasowego.

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "pixmemo-backend",
+  "version": "0.1.0",
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "start": "node src/server.js"
+  }
+}

--- a/backend/src/data.js
+++ b/backend/src/data.js
@@ -1,0 +1,149 @@
+export const photographers = [
+  {
+    id: "ph-krak-001",
+    fullName: "Anna Kowalska",
+    city: "Kraków",
+    bio: "Specjalistka od reportażu rodzinnego i sesji plenerowych.",
+    rating: 4.9,
+    reviewCount: 42,
+    verificationLevel: "video_call",
+    heroImage: "https://images.unsplash.com/photo-1524504388940-b1c1722653e1?auto=format&fit=crop&w=600&q=80",
+    specialties: ["Sesje rodzinne", "Wieczory panieńskie", "Eventy"],
+    packages: [
+      {
+        id: "pkg-anna-1",
+        name: "Mini sesja plenerowa",
+        pricePln: 350,
+        description: "45 minut fotografowania, 15 zdjęć po autorskiej obróbce.",
+      },
+      {
+        id: "pkg-anna-2",
+        name: "Reportaż rodzinny",
+        pricePln: 690,
+        description: "2 godziny, 40 zdjęć, galeria online na 60 dni.",
+      }
+    ],
+    travelPolicy: {
+      includedKm: 15,
+      extraKmPrice: 2.5,
+    },
+    availability: {
+      "2025-10-10": ["10:00", "12:00", "15:30"],
+      "2025-10-11": ["09:00", "13:00"],
+      "2025-10-15": ["17:30"],
+    },
+    testimonials: [
+      {
+        author: "Karolina",
+        rating: 5,
+        quote: "Wspaniała atmosfera, zdjęcia przyszły już po dwóch dniach!"
+      },
+      {
+        author: "Michał",
+        rating: 5,
+        quote: "Profesjonalne podejście i duża elastyczność przy rezerwacji."
+      }
+    ]
+  },
+  {
+    id: "ph-tor-002",
+    fullName: "Piotr Nowak",
+    city: "Toruń",
+    bio: "Fotograf ślubny i okolicznościowy, łączy reportaż z filmowaniem.",
+    rating: 4.7,
+    reviewCount: 31,
+    verificationLevel: "id_check",
+    heroImage: "https://images.unsplash.com/photo-1526170375885-4d8ecf77b99f?auto=format&fit=crop&w=600&q=80",
+    specialties: ["Śluby", "Chrzciny", "Sesje narzeczeńskie"],
+    packages: [
+      {
+        id: "pkg-piotr-1",
+        name: "Ceremonia + mini plener",
+        pricePln: 1200,
+        description: "Reportaż z ceremonii i mini sesja plenerowa, 80 zdjęć."
+      },
+      {
+        id: "pkg-piotr-2",
+        name: "Cały dzień ślubu",
+        pricePln: 3200,
+        description: "Od przygotowań do oczepin, 300 zdjęć, fotoksiążka 30x30cm."
+      }
+    ],
+    travelPolicy: {
+      includedKm: 30,
+      extraKmPrice: 2.2,
+    },
+    availability: {
+      "2025-10-12": ["11:00", "15:00"],
+      "2025-10-18": ["09:00"],
+      "2025-10-19": ["09:00", "12:00", "18:00"],
+    },
+    testimonials: [
+      {
+        author: "Julia",
+        rating: 5,
+        quote: "Piękne zdjęcia, złapał wszystkie ważne momenty."
+      },
+      {
+        author: "Marcin",
+        rating: 4,
+        quote: "Świetny kontakt i pomysły na ujęcia."
+      }
+    ]
+  },
+  {
+    id: "ph-gda-003",
+    fullName: "Magda Zielińska",
+    city: "Gdańsk",
+    bio: "Lifestyle i sesje biznesowe dla małych firm i freelancerów.",
+    rating: 4.8,
+    reviewCount: 19,
+    verificationLevel: "video_call",
+    heroImage: "https://images.unsplash.com/photo-1521737604893-d14cc237f11d?auto=format&fit=crop&w=600&q=80",
+    specialties: ["Sesje wizerunkowe", "Content na social media", "Eventy firmowe"],
+    packages: [
+      {
+        id: "pkg-magda-1",
+        name: "Wizerunkowa w biurze",
+        pricePln: 890,
+        description: "Sesja 3h, 25 zdjęć, konsultacja stylizacyjna online."
+      },
+      {
+        id: "pkg-magda-2",
+        name: "Dzień zdjęciowy content",
+        pricePln: 1650,
+        description: "6h zdjęć, 80 ujęć do social mediów, format pion/poziom."
+      }
+    ],
+    travelPolicy: {
+      includedKm: 20,
+      extraKmPrice: 3.0,
+    },
+    availability: {
+      "2025-10-09": ["09:00", "13:00"],
+      "2025-10-10": ["10:00", "16:00"],
+      "2025-10-14": ["12:00"],
+    },
+    testimonials: [
+      {
+        author: "Ewelina",
+        rating: 5,
+        quote: "Zdjęcia gotowe w tydzień, pięknie oddały klimat biura."
+      },
+      {
+        author: "Adam",
+        rating: 5,
+        quote: "Magda prowadzi przez cały proces, super doświadczenie."
+      }
+    ]
+  }
+];
+
+export function findPhotographer(id) {
+  return photographers.find((item) => item.id === id);
+}
+
+export function getAvailability(id) {
+  const photographer = findPhotographer(id);
+  return photographer ? photographer.availability : null;
+}

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -1,0 +1,240 @@
+import http from "http";
+import { readFile, writeFile, mkdir } from "fs/promises";
+import path from "path";
+import { fileURLToPath } from "url";
+import { photographers, findPhotographer, getAvailability } from "./data.js";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const STORAGE_DIR = path.join(__dirname, "storage");
+const BOOKINGS_FILE = path.join(STORAGE_DIR, "bookings.json");
+const PORT = process.env.PORT ? Number(process.env.PORT) : 4000;
+
+async function ensureStorageFile() {
+  await mkdir(STORAGE_DIR, { recursive: true });
+  try {
+    await readFile(BOOKINGS_FILE, "utf-8");
+  } catch (error) {
+    if (error.code === "ENOENT") {
+      await writeFile(BOOKINGS_FILE, JSON.stringify([]), "utf-8");
+    } else {
+      throw error;
+    }
+  }
+}
+
+async function readBookings() {
+  await ensureStorageFile();
+  const raw = await readFile(BOOKINGS_FILE, "utf-8");
+  return JSON.parse(raw);
+}
+
+async function writeBookings(bookings) {
+  await ensureStorageFile();
+  await writeFile(BOOKINGS_FILE, JSON.stringify(bookings, null, 2), "utf-8");
+}
+
+function parseBody(req) {
+  return new Promise((resolve, reject) => {
+    let body = "";
+    req.on("data", (chunk) => {
+      body += chunk.toString();
+      if (body.length > 1e6) {
+        req.connection.destroy();
+        reject(new Error("Payload too large"));
+      }
+    });
+    req.on("end", () => {
+      if (!body) {
+        resolve({});
+        return;
+      }
+      try {
+        const json = JSON.parse(body);
+        resolve(json);
+      } catch (err) {
+        reject(new Error("Invalid JSON payload"));
+      }
+    });
+    req.on("error", reject);
+  });
+}
+
+function sendJson(res, statusCode, payload) {
+  const data = JSON.stringify(payload);
+  res.writeHead(statusCode, {
+    "Content-Type": "application/json",
+    "Access-Control-Allow-Origin": "*",
+    "Access-Control-Allow-Methods": "GET,POST,OPTIONS",
+    "Access-Control-Allow-Headers": "Content-Type",
+  });
+  res.end(data);
+}
+
+function handleOptions(req, res) {
+  res.writeHead(204, {
+    "Access-Control-Allow-Origin": "*",
+    "Access-Control-Allow-Methods": "GET,POST,OPTIONS",
+    "Access-Control-Allow-Headers": "Content-Type",
+  });
+  res.end();
+}
+
+function validateBooking(payload) {
+  const required = [
+    "clientEmail",
+    "photographerId",
+    "packageId",
+    "date",
+    "time",
+    "addressStreet",
+    "addressCity",
+    "addressPostal",
+  ];
+
+  for (const field of required) {
+    if (!payload[field] || typeof payload[field] !== "string") {
+      return { valid: false, reason: `Brak pola: ${field}` };
+    }
+  }
+
+  const { photographerId, date, time } = payload;
+  const availability = getAvailability(photographerId);
+  if (!availability) {
+    return { valid: false, reason: "Wybrany fotograf nie istnieje." };
+  }
+
+  if (!availability[date] || !availability[date].includes(time)) {
+    return {
+      valid: false,
+      reason: "Termin niedostępny — wybierz godzinę z kalendarza fotografa.",
+    };
+  }
+
+  return { valid: true };
+}
+
+function createBooking(payload) {
+  const now = new Date().toISOString();
+  return {
+    id: `bk-${Math.random().toString(36).slice(2, 10)}`,
+    status: "pending",
+    createdAt: now,
+    updatedAt: now,
+    clientEmail: payload.clientEmail,
+    photographerId: payload.photographerId,
+    packageId: payload.packageId,
+    date: payload.date,
+    time: payload.time,
+    addressStreet: payload.addressStreet,
+    addressCity: payload.addressCity,
+    addressPostal: payload.addressPostal,
+    travelNotes: payload.travelNotes ?? "",
+    paymentMethod: payload.paymentMethod ?? "stripe",
+    priceSummary: payload.priceSummary ?? null,
+  };
+}
+
+const server = http.createServer(async (req, res) => {
+  if (!req.url) {
+    sendJson(res, 400, { error: "Invalid request" });
+    return;
+  }
+
+  const { pathname, searchParams } = new URL(req.url, `http://${req.headers.host}`);
+
+  if (req.method === "OPTIONS") {
+    handleOptions(req, res);
+    return;
+  }
+
+  if (pathname === "/api/healthz" && req.method === "GET") {
+    sendJson(res, 200, { status: "ok", timestamp: new Date().toISOString() });
+    return;
+  }
+
+  if (pathname === "/api/photographers" && req.method === "GET") {
+    const city = searchParams.get("city");
+    const data = city
+      ? photographers.filter((p) => p.city.toLowerCase() === city.toLowerCase())
+      : photographers;
+    sendJson(res, 200, data.map((p) => ({
+      id: p.id,
+      fullName: p.fullName,
+      city: p.city,
+      bio: p.bio,
+      rating: p.rating,
+      reviewCount: p.reviewCount,
+      verificationLevel: p.verificationLevel,
+      heroImage: p.heroImage,
+      specialties: p.specialties,
+      packages: p.packages,
+    })));
+    return;
+  }
+
+  const photographerMatch = pathname.match(/^\/api\/photographers\/(.+)$/);
+  if (photographerMatch && req.method === "GET") {
+    const [_, slug] = photographerMatch;
+    const parts = slug.split("/").filter(Boolean);
+    const photographerId = parts[0];
+    const subresource = parts[1];
+    const photographer = findPhotographer(photographerId);
+    if (!photographer) {
+      sendJson(res, 404, { error: "Nie znaleziono fotografa." });
+      return;
+    }
+
+    if (!subresource) {
+      sendJson(res, 200, photographer);
+      return;
+    }
+
+    if (subresource === "availability") {
+      sendJson(res, 200, photographer.availability);
+      return;
+    }
+
+    sendJson(res, 404, { error: "Nieobsługiwany zasób." });
+    return;
+  }
+
+  if (pathname === "/api/bookings" && req.method === "POST") {
+    try {
+      const body = await parseBody(req);
+      const validation = validateBooking(body);
+      if (!validation.valid) {
+        sendJson(res, 422, { error: validation.reason });
+        return;
+      }
+
+      const booking = createBooking(body);
+      const bookings = await readBookings();
+      bookings.push(booking);
+      await writeBookings(bookings);
+      sendJson(res, 201, booking);
+    } catch (error) {
+      sendJson(res, 400, { error: error.message ?? "Nieoczekiwany błąd" });
+    }
+    return;
+  }
+
+  const bookingMatch = pathname.match(/^\/api\/bookings\/([A-Za-z0-9\-]+)$/);
+  if (bookingMatch && req.method === "GET") {
+    const bookingId = bookingMatch[1];
+    const bookings = await readBookings();
+    const booking = bookings.find((item) => item.id === bookingId);
+    if (!booking) {
+      sendJson(res, 404, { error: "Nie znaleziono rezerwacji." });
+      return;
+    }
+    sendJson(res, 200, booking);
+    return;
+  }
+
+  sendJson(res, 404, { error: "Endpoint nie istnieje." });
+});
+
+server.listen(PORT, () => {
+  console.log(`PixMemo API listening on port ${PORT}`);
+});

--- a/backend/src/storage/README.md
+++ b/backend/src/storage/README.md
@@ -1,0 +1,1 @@
+Ten katalog przechowuje plik `bookings.json` generowany przez serwer podczas przyjmowania rezerwacji.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,13 @@
+# PixMemo Frontend (statyczne MVP)
+
+Ten katalog zawiera prostą implementację interfejsu PixMemo w czystym HTML/CSS/JS. Pliki mogą być serwowane spod dowolnej ścieżki (np. `/pixmemo/`), ponieważ aplikacja w locie wykrywa swój katalog poprzez `window.__PIXMEMO_PUBLIC_PATH__`.
+
+## Funkcje
+- Lista fotografów z filtrowaniem po mieście.
+- Szczegóły profilu wraz z pakietami, opiniami i polityką podróży.
+- Podgląd dostępnych terminów oraz szybkie wypełnianie formularza.
+- Formularz rezerwacji wysyłający dane do endpointu `/api/bookings`.
+- PWA: manifest + prosty service worker z cachingiem zasobów statycznych.
+
+## Konfiguracja
+Jeżeli API dostępne jest pod inną ścieżką, można zdefiniować globalną zmienną `window.__PIXMEMO_API_PREFIX__` przed załadowaniem `app.js`.

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1,0 +1,289 @@
+const API_PREFIX = window.__PIXMEMO_API_PREFIX__ ?? "/api";
+const photographerList = document.getElementById("photographerList");
+const detailContainer = document.getElementById("photographerDetail");
+const cityFilter = document.getElementById("cityFilter");
+
+const state = {
+  photographers: [],
+  filtered: [],
+  activeId: null,
+  availability: {},
+};
+
+async function fetchJSON(endpoint, options = {}) {
+  const response = await fetch(`${API_PREFIX}${endpoint}`, {
+    headers: { "Content-Type": "application/json" },
+    ...options,
+  });
+  if (!response.ok) {
+    const message = await response.text();
+    throw new Error(message || `Request failed: ${response.status}`);
+  }
+  return response.json();
+}
+
+async function loadPhotographers() {
+  try {
+    const data = await fetchJSON("/photographers");
+    state.photographers = data;
+    state.filtered = data;
+    renderList();
+  } catch (error) {
+    photographerList.innerHTML = `<li class="alert error">Nie udało się załadować listy. ${error.message}</li>`;
+  }
+}
+
+function renderList() {
+  if (!state.filtered.length) {
+    photographerList.innerHTML = `<li class="alert">Brak fotografów w tym mieście. Spróbuj rozszerzyć filtr.</li>`;
+    return;
+  }
+
+  photographerList.innerHTML = "";
+  state.filtered.forEach((photographer) => {
+    const item = document.createElement("li");
+    item.className = "photographer-card";
+    item.tabIndex = 0;
+    item.dataset.id = photographer.id;
+    item.innerHTML = `
+      <img src="${photographer.heroImage}" alt="${photographer.fullName}" />
+      <div class="photographer-meta">
+        <strong>${photographer.fullName}</strong>
+        <span class="badge">${photographer.city}</span>
+        <span>Ocena ${photographer.rating.toFixed(1)} (${photographer.reviewCount})</span>
+        <div class="specialties">
+          ${photographer.specialties.map((item) => `<span>${item}</span>`).join("")}
+        </div>
+      </div>
+    `;
+    item.addEventListener("click", () => selectPhotographer(photographer.id));
+    item.addEventListener("keypress", (event) => {
+      if (event.key === "Enter") {
+        selectPhotographer(photographer.id);
+      }
+    });
+    photographerList.appendChild(item);
+  });
+}
+
+function renderAvailability(availability, selectedDate, selectedTime) {
+  if (!availability) {
+    return "<p>Brak danych o dostępności.</p>";
+  }
+
+  const entries = Object.entries(availability);
+  if (!entries.length) {
+    return "<p>Fotograf nie udostępnił terminów.</p>";
+  }
+
+  return `
+    <div class="availability-grid">
+      ${entries
+        .map(([date, slots]) => `
+          <div class="availability-day">
+            <h4>${date}</h4>
+            <div class="slot-list">
+              ${slots
+                .map(
+                  (slot) => `
+                    <button type="button" data-date="${date}" data-time="${slot}" ${
+                      selectedDate === date && selectedTime === slot ? "data-selected=\"true\"" : ""
+                    }>
+                      ${slot}
+                    </button>
+                  `
+                )
+                .join("")}
+            </div>
+          </div>
+        `)
+        .join("")}
+    </div>
+  `;
+}
+
+async function selectPhotographer(id) {
+  state.activeId = id;
+  detailContainer.innerHTML = `<p>Ładowanie profilu...</p>`;
+  try {
+    const [profile, availability] = await Promise.all([
+      fetchJSON(`/photographers/${id}`),
+      fetchJSON(`/photographers/${id}/availability`),
+    ]);
+    state.availability[id] = availability;
+    renderDetail(profile, availability);
+  } catch (error) {
+    detailContainer.innerHTML = `<div class="alert error">Nie udało się pobrać profilu. ${error.message}</div>`;
+  }
+}
+
+function renderDetail(profile, availability) {
+  const defaultPackage = profile.packages[0];
+  detailContainer.className = "detail-card";
+  detailContainer.innerHTML = `
+    <div class="detail-hero">
+      <img src="${profile.heroImage}" alt="${profile.fullName}" />
+      <div class="info">
+        <h2>${profile.fullName}</h2>
+        <p>${profile.city} • Ocena ${profile.rating.toFixed(1)} (${profile.reviewCount})</p>
+      </div>
+    </div>
+    <section>
+      <h3>Opis</h3>
+      <p>${profile.bio}</p>
+      <div class="specialties">
+        ${profile.specialties.map((item) => `<span>${item}</span>`).join("")}
+      </div>
+    </section>
+    <section>
+      <h3>Pakiety</h3>
+      <div class="packages">
+        ${profile.packages
+          .map(
+            (pkg) => `
+              <article class="package-card">
+                <h3>${pkg.name}</h3>
+                <p>${pkg.description}</p>
+                <strong>${pkg.pricePln} PLN</strong>
+              </article>
+            `
+          )
+          .join("")}
+      </div>
+    </section>
+    <section>
+      <h3>Terminy</h3>
+      ${renderAvailability(availability)}
+    </section>
+    <section>
+      <h3>Zarezerwuj termin</h3>
+      <form class="booking-form" id="bookingForm">
+        <div id="formMessage" aria-live="polite"></div>
+        <label>
+          Adres e-mail
+          <input type="email" name="clientEmail" required placeholder="jan.kowalski@example.com" />
+        </label>
+        <label>
+          Wybierz pakiet
+          <select name="packageId">
+            ${profile.packages
+              .map(
+                (pkg) => `
+                  <option value="${pkg.id}" ${pkg.id === defaultPackage.id ? "selected" : ""}>
+                    ${pkg.name} — ${pkg.pricePln} PLN
+                  </option>
+                `
+              )
+              .join("")}
+          </select>
+        </label>
+        <label>
+          Data
+          <input type="date" name="date" required />
+        </label>
+        <label>
+          Godzina
+          <input type="time" name="time" required />
+        </label>
+        <label>
+          Ulica i numer
+          <input type="text" name="addressStreet" required />
+        </label>
+        <label>
+          Kod pocztowy
+          <input type="text" name="addressPostal" required placeholder="87-100" />
+        </label>
+        <label>
+          Miasto
+          <input type="text" name="addressCity" required />
+        </label>
+        <label>
+          Uwagi dla fotografa
+          <textarea name="travelNotes" rows="3" placeholder="np. Prosimy o kadry w złotej godzinie"></textarea>
+        </label>
+        <label>
+          Preferowana płatność
+          <select name="paymentMethod">
+            <option value="stripe">Karta/Apple Pay (Stripe)</option>
+            <option value="p24">BLIK/Przelew (Przelewy24)</option>
+          </select>
+        </label>
+        <button type="submit">Wyślij rezerwację</button>
+      </form>
+    </section>
+    <section>
+      <h3>Opinie klientów</h3>
+      <div class="packages">
+        ${profile.testimonials
+          .map(
+            (testimonial) => `
+              <article class="package-card">
+                <strong>${testimonial.author}</strong>
+                <p>Ocena: ${"★".repeat(testimonial.rating)}</p>
+                <p>${testimonial.quote}</p>
+              </article>
+            `
+          )
+          .join("")}
+      </div>
+    </section>
+  `;
+
+  const form = document.getElementById("bookingForm");
+  const messageBox = document.getElementById("formMessage");
+  const slotButtons = detailContainer.querySelectorAll(".slot-list button");
+
+  slotButtons.forEach((button) => {
+    button.addEventListener("click", () => {
+      const { date, time } = button.dataset;
+      form.elements.date.value = date;
+      form.elements.time.value = time;
+      slotButtons.forEach((btn) => btn.classList.remove("selected"));
+      button.classList.add("selected");
+    });
+  });
+
+  form.addEventListener("submit", async (event) => {
+    event.preventDefault();
+    const formData = new FormData(form);
+    const payload = Object.fromEntries(formData.entries());
+    payload.photographerId = profile.id;
+
+    messageBox.textContent = "Wysyłanie rezerwacji...";
+    messageBox.className = "alert";
+
+    try {
+      const booking = await fetchJSON("/bookings", {
+        method: "POST",
+        body: JSON.stringify(payload),
+      });
+      messageBox.textContent = `Rezerwacja przyjęta! Identyfikator: ${booking.id}`;
+      form.reset();
+    } catch (error) {
+      messageBox.textContent = error.message;
+      messageBox.className = "alert error";
+    }
+  });
+}
+
+cityFilter.addEventListener("input", (event) => {
+  const value = event.target.value.trim().toLowerCase();
+  if (!value) {
+    state.filtered = [...state.photographers];
+  } else {
+    state.filtered = state.photographers.filter((photographer) =>
+      photographer.city.toLowerCase().includes(value)
+    );
+  }
+  renderList();
+});
+
+if ("serviceWorker" in navigator) {
+  window.addEventListener("load", () => {
+    navigator.serviceWorker
+      .register("service-worker.js")
+      .catch((error) => console.error("Service worker error", error));
+  });
+}
+
+loadPhotographers();

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="pl">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>PixMemo — Rezerwuj fotografa</title>
+    <link rel="manifest" href="manifest.json" />
+    <link rel="stylesheet" href="styles.css" />
+    <link rel="icon" type="image/png" href="https://fav.farm/📸" />
+  </head>
+  <body>
+    <header class="site-header">
+      <div class="container">
+        <h1>PixMemo</h1>
+        <p class="tagline">Rezerwuj fotografów w kilka minut</p>
+      </div>
+    </header>
+    <main class="container">
+      <section class="layout">
+        <aside class="list-panel">
+          <h2>Dostępni fotografowie</h2>
+          <label class="filter">
+            <span>Miasto:</span>
+            <input id="cityFilter" type="search" placeholder="np. Toruń" />
+          </label>
+          <ul id="photographerList" class="photographer-list" aria-live="polite"></ul>
+        </aside>
+        <section class="detail-panel" aria-live="polite">
+          <div id="photographerDetail" class="detail-empty">
+            <h2>Wybierz fotografa</h2>
+            <p>
+              Kliknij kartę w liście, aby zobaczyć profil, dostępne pakiety oraz kalendarz
+              terminów. Możesz natychmiast wysłać zgłoszenie rezerwacji, które zostanie
+              zapisane w systemie API.
+            </p>
+          </div>
+        </section>
+      </section>
+    </main>
+    <footer class="site-footer">
+      <div class="container">
+        <small>&copy; 2025 PixMemo. Twoje wspomnienia, nasza odpowiedzialność.</small>
+      </div>
+    </footer>
+    <script>
+      window.__PIXMEMO_PUBLIC_PATH__ = window.location.pathname.replace(/[^/]*$/, "/");
+    </script>
+    <script src="app.js" type="module"></script>
+  </body>
+</html>

--- a/frontend/manifest.json
+++ b/frontend/manifest.json
@@ -1,0 +1,16 @@
+{
+  "name": "PixMemo",
+  "short_name": "PixMemo",
+  "start_url": "./",
+  "scope": "./",
+  "display": "standalone",
+  "background_color": "#0f172a",
+  "theme_color": "#2563eb",
+  "icons": [
+    {
+      "src": "https://fav.farm/📸",
+      "sizes": "192x192",
+      "type": "image/png"
+    }
+  ]
+}

--- a/frontend/service-worker.js
+++ b/frontend/service-worker.js
@@ -1,0 +1,54 @@
+const scopeUrl = new URL(self.location);
+const basePath = scopeUrl.pathname.replace(/service-worker\.js$/, "");
+const normalize = (value) => value.replace(/\/{2,}/g, "/");
+const assets = ["", "index.html", "styles.css", "app.js", "manifest.json"].map((asset) =>
+  normalize(`${basePath}${asset}`)
+);
+const CACHE_NAME = "pixmemo-cache-v2";
+
+self.addEventListener("install", (event) => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then((cache) => {
+      return cache.addAll(assets);
+    })
+  );
+});
+
+self.addEventListener("activate", (event) => {
+  event.waitUntil(
+    caches
+      .keys()
+      .then((keys) =>
+        Promise.all(
+          keys.map((key) => {
+            if (key !== CACHE_NAME) {
+              return caches.delete(key);
+            }
+          })
+        )
+      )
+  );
+});
+
+self.addEventListener("fetch", (event) => {
+  const { request } = event;
+  if (request.method !== "GET") {
+    return;
+  }
+
+  event.respondWith(
+    caches.match(request).then((cached) => {
+      if (cached) {
+        return cached;
+      }
+      return fetch(request).then((response) => {
+        if (!response || response.status !== 200 || response.type !== "basic") {
+          return response;
+        }
+        const responseToCache = response.clone();
+        caches.open(CACHE_NAME).then((cache) => cache.put(request, responseToCache));
+        return response;
+      });
+    })
+  );
+});

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -1,0 +1,304 @@
+:root {
+  color-scheme: light dark;
+  font-family: "Inter", "Segoe UI", sans-serif;
+  line-height: 1.6;
+  background: #0f172a;
+  color: #e2e8f0;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.container {
+  width: min(1100px, 92vw);
+  margin: 0 auto;
+}
+
+.site-header {
+  background: linear-gradient(135deg, #2563eb, #7c3aed);
+  padding: 2.5rem 0 2rem;
+  box-shadow: 0 10px 25px rgba(15, 23, 42, 0.4);
+}
+
+.site-header h1 {
+  margin: 0;
+  font-size: 2.75rem;
+  letter-spacing: -0.03em;
+}
+
+.tagline {
+  margin: 0.35rem 0 0;
+  font-size: 1.1rem;
+  opacity: 0.9;
+}
+
+.site-footer {
+  background: rgba(15, 23, 42, 0.9);
+  margin-top: auto;
+  padding: 1.5rem 0;
+  text-align: center;
+  font-size: 0.85rem;
+  color: rgba(226, 232, 240, 0.65);
+}
+
+.layout {
+  display: grid;
+  grid-template-columns: 320px 1fr;
+  gap: 1.5rem;
+  padding: 2rem 0 3rem;
+}
+
+.list-panel,
+.detail-panel {
+  background: rgba(15, 23, 42, 0.55);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  border-radius: 22px;
+  padding: 1.5rem;
+  box-shadow: 0 18px 35px rgba(15, 23, 42, 0.45);
+  backdrop-filter: blur(12px);
+}
+
+.list-panel h2,
+.detail-panel h2 {
+  margin-top: 0;
+  font-size: 1.3rem;
+}
+
+.filter {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  margin-bottom: 1.2rem;
+  font-size: 0.95rem;
+}
+
+.filter input {
+  padding: 0.55rem 0.7rem;
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(15, 23, 42, 0.75);
+  color: inherit;
+}
+
+.photographer-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.photographer-card {
+  display: grid;
+  grid-template-columns: 88px 1fr;
+  gap: 1rem;
+  padding: 1rem;
+  border-radius: 18px;
+  background: rgba(30, 41, 59, 0.6);
+  border: 1px solid transparent;
+  cursor: pointer;
+  transition: transform 0.18s ease, border-color 0.18s ease, box-shadow 0.18s ease;
+}
+
+.photographer-card:hover,
+.photographer-card:focus {
+  transform: translateY(-3px);
+  border-color: rgba(129, 140, 248, 0.65);
+  box-shadow: 0 18px 28px rgba(30, 41, 59, 0.45);
+}
+
+.photographer-card img {
+  width: 88px;
+  height: 88px;
+  border-radius: 14px;
+  object-fit: cover;
+}
+
+.photographer-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.18rem 0.55rem;
+  border-radius: 999px;
+  background: rgba(129, 140, 248, 0.2);
+  font-size: 0.75rem;
+}
+
+.specialties {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  font-size: 0.75rem;
+}
+
+.specialties span {
+  background: rgba(56, 189, 248, 0.18);
+  padding: 0.2rem 0.55rem;
+  border-radius: 999px;
+}
+
+.detail-empty {
+  text-align: center;
+  padding: 3rem 1rem;
+  color: rgba(226, 232, 240, 0.7);
+}
+
+.detail-card {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.detail-hero {
+  position: relative;
+  border-radius: 24px;
+  overflow: hidden;
+  min-height: 200px;
+  background: rgba(30, 41, 59, 0.6);
+}
+
+.detail-hero img {
+  width: 100%;
+  height: 240px;
+  object-fit: cover;
+  filter: brightness(0.85);
+}
+
+.detail-hero .info {
+  position: absolute;
+  inset: auto 0 0 0;
+  padding: 1.25rem;
+  background: linear-gradient(180deg, rgba(15, 23, 42, 0) 0%, rgba(15, 23, 42, 0.9) 100%);
+}
+
+.info h2 {
+  margin: 0;
+  font-size: 1.8rem;
+}
+
+.packages {
+  display: grid;
+  gap: 1rem;
+}
+
+.package-card {
+  padding: 1rem;
+  border-radius: 16px;
+  background: rgba(15, 23, 42, 0.6);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+}
+
+.package-card h3 {
+  margin: 0 0 0.35rem;
+}
+
+.availability-grid {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.availability-day {
+  background: rgba(56, 189, 248, 0.14);
+  border-radius: 14px;
+  padding: 0.75rem;
+}
+
+.availability-day h4 {
+  margin: 0 0 0.35rem;
+  font-size: 1rem;
+}
+
+.slot-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+}
+
+.slot-list button {
+  padding: 0.35rem 0.65rem;
+  border-radius: 999px;
+  border: none;
+  cursor: pointer;
+  background: rgba(59, 130, 246, 0.9);
+  color: white;
+  font-weight: 600;
+  transition: transform 0.15s ease;
+}
+
+.slot-list button:hover,
+.slot-list button:focus {
+  transform: translateY(-2px);
+}
+
+.booking-form {
+  display: grid;
+  gap: 0.8rem;
+  margin-top: 0.5rem;
+}
+
+.booking-form label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  font-size: 0.85rem;
+}
+
+.booking-form input,
+.booking-form textarea,
+.booking-form select {
+  padding: 0.55rem 0.7rem;
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(15, 23, 42, 0.85);
+  color: inherit;
+}
+
+.booking-form button[type="submit"] {
+  margin-top: 0.5rem;
+  padding: 0.65rem 0.9rem;
+  border-radius: 12px;
+  border: none;
+  cursor: pointer;
+  background: linear-gradient(135deg, #22d3ee, #6366f1);
+  color: #0f172a;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.alert {
+  padding: 0.75rem 1rem;
+  border-radius: 12px;
+  background: rgba(34, 197, 94, 0.16);
+  border: 1px solid rgba(34, 197, 94, 0.4);
+}
+
+.alert.error {
+  background: rgba(248, 113, 113, 0.16);
+  border-color: rgba(248, 113, 113, 0.4);
+}
+
+@media (max-width: 900px) {
+  .layout {
+    grid-template-columns: 1fr;
+  }
+
+  .list-panel {
+    order: 2;
+  }
+
+  .detail-panel {
+    order: 1;
+  }
+}


### PR DESCRIPTION
## Summary
- add a standalone Node.js HTTP API exposing mock PixMemo endpoints and file-based bookings persistence
- build a static HTML/CSS/JS frontend PWA that consumes the API for browsing photographers and submitting bookings
- document repository usage and configuration for the backend and frontend stacks

## Testing
- node backend/src/server.js

------
https://chatgpt.com/codex/tasks/task_e_68e518f47c48832489984023051a5ee1